### PR TITLE
Namespace test mocks

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -288,7 +288,9 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///
     /// - Note: Generated files must be manually added to your test target. Test mocks generated
     /// this way may also be manually embedded in a test utility module that is imported by your
-    /// test target.
+    /// test target. The generated test mock types files will be namespaced with the value of your
+    /// configuration's `schemaName` and appending the suffix "TestMocks" when your schema types
+    /// configuration also uses namespacing.
     case absolute(path: String)
     /// Generated test mock files will be included in a target defined in the generated
     /// `Package.swift` file that is suitable for linking the generated test mock files to your
@@ -730,6 +732,16 @@ extension ApolloCodegenConfiguration.OperationsFileOutput {
     switch self {
     case .inSchemaModule: return true
     case .absolute, .relative: return false
+    }
+  }
+}
+
+extension ApolloCodegenConfiguration.TestMockFileOutput {
+  /// Determine whether the test mock files are output to a module.
+  var isInModule: Bool {
+    switch self {
+    case .swiftPackage: return true
+    case .absolute, .none: return false
     }
   }
 }

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -114,7 +114,7 @@ extension TemplateRenderer {
     \(ifLet: headerTemplate, { "\($0)\n" })
     \(ImportStatementTemplate.Operation.template(for: config))
 
-    \(if: config.output.operations.isInModule && !config.output.schemaTypes.isInModule,
+    \(if: config.needsWrappedInNamespace,
       template.wrappedInNamespace(config.schemaName.firstUppercased),
     else:
       template)
@@ -137,7 +137,7 @@ extension TemplateRenderer {
     \(ifLet: headerTemplate, { "\($0)\n" })
     \(ImportStatementTemplate.TestMock.template(for: config))
 
-    \(if: !config.output.testMocks.isInModule && config.output.operations.isInModule && !config.output.schemaTypes.isInModule,
+    \(if: config.needsWrappedInNamespace,
       template.wrappedInNamespace("\(config.schemaName.firstUppercased)TestMocks"),
     else:
       template)

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -137,7 +137,10 @@ extension TemplateRenderer {
     \(ifLet: headerTemplate, { "\($0)\n" })
     \(ImportStatementTemplate.TestMock.template(for: config))
 
-    \(template)
+    \(if: !config.output.testMocks.isInModule && config.output.operations.isInModule && !config.output.schemaTypes.isInModule,
+      template.wrappedInNamespace("\(config.schemaName.firstUppercased)TestMocks"),
+    else:
+      template)
     """
     ).description
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
@@ -11,13 +11,14 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
     schemaName: String = "testSchema",
     operations: ApolloCodegenConfiguration.OperationsFileOutput,
-    cocoapodsCompatibleImportStatements: Bool = false
+    cocoapodsCompatibleImportStatements: Bool = false,
+    alwaysWrapInNamespace: Bool = false
   ) -> ApolloCodegenConfiguration {
     ApolloCodegenConfiguration.mock(
       schemaName: schemaName,
       input: .init(schemaPath: "MockInputPath", operationSearchPaths: []),
       output: .mock(moduleType: moduleType, operations: operations),
-      options: .init(cocoapodsCompatibleImportStatements: cocoapodsCompatibleImportStatements)
+      options: .init(cocoapodsCompatibleImportStatements: cocoapodsCompatibleImportStatements, alwaysWrapInNamespace: alwaysWrapInNamespace)
     )
   }
 
@@ -251,67 +252,140 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
     let tests: [(
       schemaTypes: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
       operations: ApolloCodegenConfiguration.OperationsFileOutput,
+      forceNamespace: Bool,
       expectation: String,
       atLine: Int
     )] = [
       (
         schemaTypes: .swiftPackageManager,
         operations: .relative(subpath: nil),
+        forceNamespace: false,
+        expectation: expectedNoNamespace,
+        atLine: 7
+      ),
+      (
+        schemaTypes: .swiftPackageManager,
+        operations: .relative(subpath: nil),
+        forceNamespace: true,
+        expectation: expectedNamespace,
+        atLine: 7
+      ),
+      (
+        schemaTypes: .swiftPackageManager,
+        operations: .absolute(path: "path"),
+        forceNamespace: false,
         expectation: expectedNoNamespace,
         atLine: 7
       ),
       (
         schemaTypes: .swiftPackageManager,
         operations: .absolute(path: "path"),
-        expectation: expectedNoNamespace,
+        forceNamespace: true,
+        expectation: expectedNamespace,
         atLine: 7
       ),
       (
         schemaTypes: .swiftPackageManager,
         operations: .inSchemaModule,
+        forceNamespace: false,
         expectation: expectedNoNamespace,
+        atLine: 6
+      ),
+      (
+        schemaTypes: .swiftPackageManager,
+        operations: .inSchemaModule,
+        forceNamespace: true,
+        expectation: expectedNamespace,
         atLine: 6
       ),
       (
         schemaTypes: .other,
         operations: .relative(subpath: nil),
+        forceNamespace: false,
+        expectation: expectedNoNamespace,
+        atLine: 7
+      ),
+      (
+        schemaTypes: .other,
+        operations: .relative(subpath: nil),
+        forceNamespace: true,
+        expectation: expectedNamespace,
+        atLine: 7
+      ),
+      (
+        schemaTypes: .other,
+        operations: .absolute(path: "path"),
+        forceNamespace: false,
         expectation: expectedNoNamespace,
         atLine: 7
       ),
       (
         schemaTypes: .other,
         operations: .absolute(path: "path"),
-        expectation: expectedNoNamespace,
+        forceNamespace: true,
+        expectation: expectedNamespace,
         atLine: 7
       ),
       (
         schemaTypes: .other,
         operations: .inSchemaModule,
+        forceNamespace: false,
         expectation: expectedNoNamespace,
+        atLine: 6
+      ),
+      (
+        schemaTypes: .other,
+        operations: .inSchemaModule,
+        forceNamespace: true,
+        expectation: expectedNamespace,
         atLine: 6
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .relative(subpath: nil),
+        forceNamespace: false,
+        expectation: expectedNoNamespace,
+        atLine: 7
+      ),
+      (
+        schemaTypes: .embeddedInTarget(name: "MockApplication"),
+        operations: .relative(subpath: nil),
+        forceNamespace: true,
+        expectation: expectedNamespace,
+        atLine: 7
+      ),
+      (
+        schemaTypes: .embeddedInTarget(name: "MockApplication"),
+        operations: .absolute(path: "path"),
+        forceNamespace: false,
         expectation: expectedNoNamespace,
         atLine: 7
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .absolute(path: "path"),
-        expectation: expectedNoNamespace,
+        forceNamespace: true,
+        expectation: expectedNamespace,
         atLine: 7
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .inSchemaModule,
+        forceNamespace: false,
+        expectation: expectedNamespace,
+        atLine: 6
+      ),
+      (
+        schemaTypes: .embeddedInTarget(name: "MockApplication"),
+        operations: .inSchemaModule,
+        forceNamespace: true,
         expectation: expectedNamespace,
         atLine: 6
       )
     ]
 
     for test in tests {
-      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations, alwaysWrapInNamespace: test.forceNamespace)
       let subject = buildSubject(config: config)
 
       // when

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_TestMockFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_TestMockFile_Tests.swift
@@ -11,13 +11,14 @@ class TemplateRenderer_TestMockFile_Tests: XCTestCase {
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
     schemaName: String = "testSchema",
     operations: ApolloCodegenConfiguration.OperationsFileOutput,
-    cocoapodsCompatibleImportStatements: Bool = false
+    cocoapodsCompatibleImportStatements: Bool = false,
+    alwaysWrapInNamespace: Bool = false
   ) -> ApolloCodegenConfiguration {
     ApolloCodegenConfiguration.mock(
       schemaName: schemaName,
       input: .init(schemaPath: "MockInputPath", operationSearchPaths: []),
       output: .mock(moduleType: moduleType, operations: operations),
-      options: .init(cocoapodsCompatibleImportStatements: cocoapodsCompatibleImportStatements)
+      options: .init(cocoapodsCompatibleImportStatements: cocoapodsCompatibleImportStatements, alwaysWrapInNamespace: alwaysWrapInNamespace)
     )
   }
 
@@ -81,57 +82,121 @@ class TemplateRenderer_TestMockFile_Tests: XCTestCase {
     let tests: [(
       schemaTypes: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
       operations: ApolloCodegenConfiguration.OperationsFileOutput,
+      forceNamespace: Bool,
       expectation: String
     )] = [
       (
         schemaTypes: .swiftPackageManager,
         operations: .relative(subpath: nil),
+        forceNamespace: false,
+        expectation: expectedNoNamespace
+      ),
+      (
+        schemaTypes: .swiftPackageManager,
+        operations: .relative(subpath: nil),
+        forceNamespace: true,
+        expectation: expectedNamespace
+      ),
+      (
+        schemaTypes: .swiftPackageManager,
+        operations: .absolute(path: "path"),
+        forceNamespace: false,
         expectation: expectedNoNamespace
       ),
       (
         schemaTypes: .swiftPackageManager,
         operations: .absolute(path: "path"),
+        forceNamespace: true,
+        expectation: expectedNamespace
+      ),
+      (
+        schemaTypes: .swiftPackageManager,
+        operations: .inSchemaModule,
+        forceNamespace: false,
         expectation: expectedNoNamespace
       ),
       (
         schemaTypes: .swiftPackageManager,
         operations: .inSchemaModule,
+        forceNamespace: true,
+        expectation: expectedNamespace
+      ),
+      (
+        schemaTypes: .other,
+        operations: .relative(subpath: nil),
+        forceNamespace: false,
         expectation: expectedNoNamespace
       ),
       (
         schemaTypes: .other,
         operations: .relative(subpath: nil),
+        forceNamespace: true,
+        expectation: expectedNamespace
+      ),
+      (
+        schemaTypes: .other,
+        operations: .absolute(path: "path"),
+        forceNamespace: false,
         expectation: expectedNoNamespace
       ),
       (
         schemaTypes: .other,
         operations: .absolute(path: "path"),
+        forceNamespace: true,
+        expectation: expectedNamespace
+      ),
+      (
+        schemaTypes: .other,
+        operations: .inSchemaModule,
+        forceNamespace: false,
         expectation: expectedNoNamespace
       ),
       (
         schemaTypes: .other,
         operations: .inSchemaModule,
+        forceNamespace: true,
+        expectation: expectedNamespace
+      ),
+      (
+        schemaTypes: .embeddedInTarget(name: "MockApplication"),
+        operations: .relative(subpath: nil),
+        forceNamespace: false,
         expectation: expectedNoNamespace
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .relative(subpath: nil),
+        forceNamespace: true,
+        expectation: expectedNamespace
+      ),
+      (
+        schemaTypes: .embeddedInTarget(name: "MockApplication"),
+        operations: .absolute(path: "path"),
+        forceNamespace: false,
         expectation: expectedNoNamespace
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .absolute(path: "path"),
-        expectation: expectedNoNamespace
+        forceNamespace: true,
+        expectation: expectedNamespace
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .inSchemaModule,
+        forceNamespace: false,
+        expectation: expectedNamespace
+      ),
+      (
+        schemaTypes: .embeddedInTarget(name: "MockApplication"),
+        operations: .inSchemaModule,
+        forceNamespace: true,
         expectation: expectedNamespace
       )
     ]
 
     for test in tests {
-      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations, alwaysWrapInNamespace: test.forceNamespace)
       let subject = buildSubject(config: config)
 
       // when

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_TestMockFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_TestMockFile_Tests.swift
@@ -62,6 +62,87 @@ class TemplateRenderer_TestMockFile_Tests: XCTestCase {
     }
   }
 
+  func test__renderTargetTestMockFile__givenAllSchemaTypesOperationsCombinations_conditionallyWrapInNamespace() {
+    // given
+    let expectedNoNamespace = """
+    root {
+      nested
+    }
+    """
+
+    let expectedNamespace = """
+    public extension TestSchemaTestMocks {
+      root {
+        nested
+      }
+    }
+    """
+
+    let tests: [(
+      schemaTypes: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
+      operations: ApolloCodegenConfiguration.OperationsFileOutput,
+      expectation: String
+    )] = [
+      (
+        schemaTypes: .swiftPackageManager,
+        operations: .relative(subpath: nil),
+        expectation: expectedNoNamespace
+      ),
+      (
+        schemaTypes: .swiftPackageManager,
+        operations: .absolute(path: "path"),
+        expectation: expectedNoNamespace
+      ),
+      (
+        schemaTypes: .swiftPackageManager,
+        operations: .inSchemaModule,
+        expectation: expectedNoNamespace
+      ),
+      (
+        schemaTypes: .other,
+        operations: .relative(subpath: nil),
+        expectation: expectedNoNamespace
+      ),
+      (
+        schemaTypes: .other,
+        operations: .absolute(path: "path"),
+        expectation: expectedNoNamespace
+      ),
+      (
+        schemaTypes: .other,
+        operations: .inSchemaModule,
+        expectation: expectedNoNamespace
+      ),
+      (
+        schemaTypes: .embeddedInTarget(name: "MockApplication"),
+        operations: .relative(subpath: nil),
+        expectation: expectedNoNamespace
+      ),
+      (
+        schemaTypes: .embeddedInTarget(name: "MockApplication"),
+        operations: .absolute(path: "path"),
+        expectation: expectedNoNamespace
+      ),
+      (
+        schemaTypes: .embeddedInTarget(name: "MockApplication"),
+        operations: .inSchemaModule,
+        expectation: expectedNamespace
+      )
+    ]
+
+    for test in tests {
+      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let subject = buildSubject(config: config)
+
+      // when
+      let actual = subject.render()
+      print(actual)
+
+      // then
+      expect(actual).to(equalLineByLine(test.expectation, atLine: 7))
+    }
+  }
+
   func test__renderTargetSchemaFile__givenAllSchemaTypesOperationsCombinations_conditionallyImportSchemaModule() {
     // given
     let tests: [(


### PR DESCRIPTION
- Defaults to additional namespacing of test mock types when codegen is also namespacing schema types
- Allows opting into namespacing of schema and mock types for any codegen configuration